### PR TITLE
Making pads respond to click and touch events

### DIFF
--- a/main.js
+++ b/main.js
@@ -13,7 +13,13 @@ function removeTransition(e) {
 }
 
 const pads =  document.querySelectorAll('.pad');
-pads.forEach(key => key.addEventListener('click', playSound));
+pads.forEach( pad => {
+
+  let e = new KeyboardEvent('keydown', { keyCode: pad.getAttribute('data-key') });
+
+  pad.addEventListener('click', () => playSound(e) );
+  pad.addEventListener('touchstart', () => playSound(e) );
+});
 pads.forEach(key => key.addEventListener('transitionend', removeTransition));
 
 window.addEventListener('keydown', playSound);


### PR DESCRIPTION
Since the `playSound` function expects a `keydown` event to be passed to it, we kinda have to manufacture a `keydown` event which is to be triggered by a click/touch event.

This isn't the most maintainable approach, but it works :)  It feels like if more functionality were to get added on, though, then we'd be bending over backwards just to have everything work in terms of a keydown event.

P.S. Great job on creating a sweet-looking drum machine using SVG!